### PR TITLE
Add CI workflow and release scaffolding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build
+        run: go build ./...
+      - name: Test
+        run: go test ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release'
+        required: true
+
+env:
+  PUBLISH_TO_TERRAFORM_REGISTRY: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Build provider
+        run: go build -o terraform-provider-stepca
+      - name: Publish to Terraform Registry
+        if: env.PUBLISH_TO_TERRAFORM_REGISTRY == 'true'
+        env:
+          TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+        run: |
+          terraform providers push \
+            --os=linux --arch=amd64 \
+            --version ${{ github.event.inputs.version }} \
+            terraform-provider-stepca

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+build:
+	go build
+
+test:
+	go test ./...
+
+release:
+	scripts/release.sh $(VERSION)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,29 @@
 
 This is an experimental Terraform provider for interacting with a self-hosted [step-ca](https://github.com/smallstep/certificates) instance. It exposes a simple resource for signing certificates using the `/sign` API endpoint.
 
+## Requirements
+
+* [Go](https://go.dev/) 1.24 or newer must be installed and in your `PATH`.
+* The `terraform` CLI is only required when publishing to the Terraform registry.
+
 ## Building
 
 ```
-go build
+make build
+```
+
+## Testing
+
+```
+make test
+```
+
+## Releasing
+
+A helper script is provided for publishing the provider to the Terraform registry when it is ready. The actual release is disabled by default and requires setting `PUBLISH_TO_TERRAFORM_REGISTRY=true`.
+
+```
+PUBLISH_TO_TERRAFORM_REGISTRY=true make release VERSION=v0.1.0
 ```
 
 ## Example Usage

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:-}"
+if [[ -z "$VERSION" ]]; then
+  echo "Usage: $0 <version>"
+  exit 1
+fi
+
+if [[ "${PUBLISH_TO_TERRAFORM_REGISTRY:-false}" != "true" ]]; then
+  echo "Publishing disabled. Set PUBLISH_TO_TERRAFORM_REGISTRY=true when ready."
+  exit 0
+fi
+
+# Build provider binary
+GOOS=linux GOARCH=amd64 go build -o terraform-provider-stepca
+
+echo "Pushing provider version $VERSION to Terraform Registry"
+terraform providers push \
+  --os=linux --arch=amd64 \
+  --version "$VERSION" \
+  terraform-provider-stepca


### PR DESCRIPTION
## Summary
- document requirements for building and testing
- add Makefile with build, test and release tasks
- add CI workflow to build and test
- add release workflow and script with publishing disabled by default

## Testing
- `go test ./...`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687402851818832eb65352d8a340070f