### PR TITLE
Add test release workflow and packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,13 @@
 name: Release
 
 on:
+  push:
+    branches: [ main ]
   workflow_dispatch:
     inputs:
       version:
         description: 'Version to release'
-        required: true
+        required: false
 
 env:
   PUBLISH_TO_TERRAFORM_REGISTRY: false
@@ -18,8 +20,16 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: Build provider
-        run: go build -o terraform-provider-stepca
+      - name: Set release version
+        run: |
+          if [ -z "${{ github.event.inputs.version }}" ]; then
+            echo "VERSION=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          else
+            echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+          fi
+      - name: Build and package provider
+        run: |
+          make package VERSION=$VERSION
       - name: Publish to Terraform Registry
         if: env.PUBLISH_TO_TERRAFORM_REGISTRY == 'true'
         env:
@@ -27,5 +37,20 @@ jobs:
         run: |
           terraform providers push \
             --os=linux --arch=amd64 \
-            --version ${{ github.event.inputs.version }} \
+            --version $VERSION \
             terraform-provider-stepca
+      - name: Create GitHub Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ env.VERSION }}
+          name: Test release ${{ env.VERSION }}
+          draft: false
+          prerelease: true
+      - name: Upload provider asset
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: dist/terraform-provider-stepca_${{ env.VERSION }}_linux_amd64.zip
+          asset_name: terraform-provider-stepca_${{ env.VERSION }}_linux_amd64.zip
+          asset_content_type: application/zip

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,17 @@
-build:
-	go build
+BINARY := terraform-provider-stepca
+VERSION ?= $(shell git rev-parse --short HEAD)
+DIST_DIR := dist
+
+.PHONY: build binary package test release
+
+build: package
+
+binary:
+	GOOS=linux GOARCH=amd64 go build -o $(BINARY)
+
+package: binary
+	mkdir -p $(DIST_DIR)
+	zip $(DIST_DIR)/$(BINARY)_$(VERSION)_linux_amd64.zip $(BINARY)
 
 test:
 	go test ./...

--- a/README.md
+++ b/README.md
@@ -41,3 +41,25 @@ resource "stepca_certificate" "example" {
 ```
 
 The resulting certificate will be available as the `certificate` attribute.
+
+## Test Releases
+
+Every push to `main` publishes a prerelease on GitHub using the latest commit
+hash as the version. The packaged provider binary is uploaded as
+`terraform-provider-stepca_<commit>_linux_amd64.zip`.
+
+To use a test build from this repository specify the commit hash as the provider
+version:
+
+```hcl
+terraform {
+  required_providers {
+    stepca = {
+      source  = "github.com/z0link/terraform-provider-stepca"
+      version = "<commit>"
+    }
+  }
+}
+```
+
+Replace `<commit>` with the hash shown on the GitHub releases page.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,22 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VERSION="${1:-}"
-if [[ -z "$VERSION" ]]; then
-  echo "Usage: $0 <version>"
-  exit 1
+VERSION="${1:-$(git rev-parse --short HEAD)}"
+BINARY="terraform-provider-stepca"
+DIST_DIR="dist"
+
+echo "Building provider binary..."
+GOOS=linux GOARCH=amd64 go build -o "$BINARY"
+
+mkdir -p "$DIST_DIR"
+zip "$DIST_DIR/${BINARY}_${VERSION}_linux_amd64.zip" "$BINARY"
+
+if [[ "${PUBLISH_TO_TERRAFORM_REGISTRY:-false}" == "true" ]]; then
+  echo "Pushing provider version $VERSION to Terraform Registry"
+  terraform providers push \
+    --os=linux --arch=amd64 \
+    --version "$VERSION" \
+    "$BINARY"
 fi
-
-if [[ "${PUBLISH_TO_TERRAFORM_REGISTRY:-false}" != "true" ]]; then
-  echo "Publishing disabled. Set PUBLISH_TO_TERRAFORM_REGISTRY=true when ready."
-  exit 0
-fi
-
-# Build provider binary
-GOOS=linux GOARCH=amd64 go build -o terraform-provider-stepca
-
-echo "Pushing provider version $VERSION to Terraform Registry"
-terraform providers push \
-  --os=linux --arch=amd64 \
-  --version "$VERSION" \
-  terraform-provider-stepca


### PR DESCRIPTION
## Summary
- build packages provider zip with commit hash
- release workflow produces prerelease using commit hash
- make release script create package & optionally publish
- document test releases and usage

## Testing
- `make build`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68740c333330832e941c655d6b89d859