### PR TITLE
Implement version data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ resource "stepca_certificate" "example" {
 
 The resulting certificate will be available as the `certificate` attribute.
 
+### Data Sources
+
+Query the CA version:
+
+```hcl
+data "stepca_version" "current" {}
+```
+
+The version string will be available as `data.stepca_version.current.version`.
+
 ## Test Releases
 
 Every push to `main` publishes a prerelease on GitHub using the latest commit

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 )
 
@@ -45,4 +46,25 @@ func (c *Client) Sign(ctx context.Context, csr string) ([]byte, error) {
 		return nil, err
 	}
 	return []byte(result.Cert), nil
+}
+
+// Version retrieves the version string from the /version endpoint.
+func (c *Client) Version(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/version", c.baseURL), nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes.TrimSpace(b)), nil
 }

--- a/internal/provider/data_source_version.go
+++ b/internal/provider/data_source_version.go
@@ -1,0 +1,63 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/z0link/terraform-provider-stepca/internal/client"
+)
+
+var _ datasource.DataSource = &versionDataSource{}
+
+func NewVersionDataSource() datasource.DataSource {
+	return &versionDataSource{}
+}
+
+type versionDataSource struct {
+	client *client.Client
+}
+
+type versionDataSourceModel struct {
+	Version types.String `tfsdk:"version"`
+}
+
+func (d *versionDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "stepca_version"
+}
+
+func (d *versionDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"version": schema.StringAttribute{Computed: true},
+		},
+	}
+}
+
+func (d *versionDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	if c, ok := req.ProviderData.(*client.Client); ok {
+		d.client = c
+	}
+}
+
+func (d *versionDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	if d.client == nil {
+		resp.Diagnostics.AddError("provider not configured", "missing client")
+		return
+	}
+
+	version, err := d.client.Version(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("version fetch failed", err.Error())
+		return
+	}
+
+	data := versionDataSourceModel{Version: types.StringValue(version)}
+	diags := resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -60,5 +60,7 @@ func (p *stepcaProvider) Resources(ctx context.Context) []func() resource.Resour
 }
 
 func (p *stepcaProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
-	return nil
+	return []func() datasource.DataSource{
+		NewVersionDataSource,
+	}
 }


### PR DESCRIPTION
## Summary
- add `stepca_version` data source
- expose the data source in the provider
- implement `/version` call in the client
- document how to query the CA version

## Testing
- `go build ./...` *(fails: proxyconnect tcp: dial tcp 172.30.0.19:8080: connect: no route to host)*
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.30.0.19:8080: connect: no route to host)*

------
https://chatgpt.com/codex/tasks/task_e_6877771ae2c0832eb0967393799551dc