### PR TITLE
Fix release permissions and add automation docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
         description: 'Version to release'
         required: false
 
+permissions:
+  contents: write
+
 env:
   PUBLISH_TO_TERRAFORM_REGISTRY: false
 

--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -1,0 +1,26 @@
+# Automation Instructions
+
+This repository uses GitHub Actions to build and publish test releases of the Terraform provider.
+
+The main workflow is defined in `.github/workflows/release.yml`. Every push to `main` builds the provider and creates a prerelease on GitHub.
+
+## Permissions
+
+The workflow relies on the built in `GITHUB_TOKEN`. Ensure the workflow has permission to write repository contents:
+
+```yaml
+permissions:
+  contents: write
+```
+
+With these permissions the release step can create a GitHub release and upload the packaged binary.
+
+## Publishing to the Terraform Registry
+
+Publishing to the Terraform Registry is optional. Set the environment variable `PUBLISH_TO_TERRAFORM_REGISTRY=true` and provide a `TF_API_TOKEN` secret to enable it.
+
+## Dependencies
+
+- Go 1.24 or newer must be available on the runner.
+- The `terraform` CLI is required only when pushing to the Terraform Registry.
+- `zip` is used by the packaging script (already installed on GitHub hosted runners).


### PR DESCRIPTION
## Summary
- give the release workflow `contents: write` permission so the default GITHUB_TOKEN can create a release
- add AUTOMATION.md with notes about the GitHub Actions workflows and required dependencies

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68777bbb8170832eb72add47f0b2fbd2