### PR TITLE
Add .gitignore for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Binaries for programs and plugins
+terraform-provider-stepca
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Build directories
+/dist/
+/bin/
+
+# Archived build artifacts
+*.tar.gz
+*.zip
+
+# Step CA initialization files
+config/
+certs/
+secrets/
+password.txt
+*.pem
+*.key
+*.crt
+
+# Terraform local data
+.terraform/
+
+# Go build cache
+*.test
+*.out


### PR DESCRIPTION
## Summary
- keep build outputs out of git by adding `.gitignore`

## Testing
- `make test`
- `apt-get install terraform` *(fails: Unable to locate package)*
- `curl -L https://dl.smallstep.com/.../step-cli_amd64.deb` *(fails: Not Found)*
- `curl -L https://dl.smallstep.com/.../step-ca_amd64.deb` *(fails: Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_687785fcef54832e89d2b8fc7b0b96c7