### PR TITLE
Update release versioning scheme

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,23 @@ jobs:
         if: github.ref == 'refs/heads/main' || steps.changes.outputs.provider == 'true' || github.event_name == 'workflow_dispatch'
         with:
           go-version-file: go.mod
+      - name: Install step dependencies
+        if: github.ref == 'refs/heads/main' || steps.changes.outputs.provider == 'true' || github.event_name == 'workflow_dispatch'
+        run: |
+          curl -L https://github.com/smallstep/cli/releases/latest/download/step-cli_amd64.deb -o step-cli.deb
+          sudo dpkg -i step-cli.deb
+          curl -L https://github.com/smallstep/certificates/releases/latest/download/step-ca_amd64.deb -o step-ca.deb
+          sudo dpkg -i step-ca.deb
       - name: Set release version
         if: github.ref == 'refs/heads/main' || steps.changes.outputs.provider == 'true' || github.event_name == 'workflow_dispatch'
         run: |
+          COMMIT_TAG=$(git tag --points-at HEAD | head -n 1)
+          if [ -z "$COMMIT_TAG" ]; then
+            COMMIT_TAG=$(git rev-parse --short=6 HEAD)
+          fi
+          STEP_VERSION=$(step version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
           if [ -z "${{ github.event.inputs.version }}" ]; then
-            echo "VERSION=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+            echo "VERSION=stepca-${STEP_VERSION}-${COMMIT_TAG}" >> $GITHUB_ENV
           else
             echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
           fi

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 BINARY := terraform-provider-stepca
-VERSION ?= $(shell git rev-parse --short HEAD)
+STEP_VERSION := $(shell step version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
+COMMIT_TAG := $(shell git tag --points-at HEAD | head -n 1)
+ifeq ($(strip $(COMMIT_TAG)),)
+COMMIT_TAG := $(shell git rev-parse --short=6 HEAD)
+endif
+VERSION ?= stepca-$(STEP_VERSION)-$(COMMIT_TAG)
 DIST_DIR := dist
 
 .PHONY: build binary package test release

--- a/README.md
+++ b/README.md
@@ -70,15 +70,22 @@ is not tagged the first six characters of the commit hash are used. The packaged
 provider binary is uploaded as
 `terraform-provider-stepca_stepca-<step-version>-<commit>_linux_amd64.zip`.
 
-To use a test build from this repository specify that version string as the provider
-version:
+Terraform only accepts semantic version numbers. After extracting a prerelease
+binary, rename it to a valid version before running `terraform init`. One option
+is to rename the file to `terraform-provider-stepca_v0.0.0` and reference that
+version in your configuration:
+
+```bash
+unzip terraform-provider-stepca_stepca-<step-version>-<commit>_linux_amd64.zip
+mv terraform-provider-stepca terraform-provider-stepca_v0.0.0
+```
 
 ```hcl
 terraform {
   required_providers {
     stepca = {
-      source  = "github.com/z0link/terraform-provider-stepca"
-      version = "stepca-<step-version>-<commit>"
+      source  = "local/stepca"
+      version = "0.0.0"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -64,11 +64,13 @@ The version string will be available as `data.stepca_version.current.version`.
 
 ## Test Releases
 
-Every push to `main` publishes a prerelease on GitHub using the latest commit
-hash as the version. The packaged provider binary is uploaded as
-`terraform-provider-stepca_<commit>_linux_amd64.zip`.
+Every push to `main` publishes a prerelease on GitHub using a version string
+that combines the installed `step` CLI version and the commit tag. If the commit
+is not tagged the first six characters of the commit hash are used. The packaged
+provider binary is uploaded as
+`terraform-provider-stepca_stepca-<step-version>-<commit>_linux_amd64.zip`.
 
-To use a test build from this repository specify the commit hash as the provider
+To use a test build from this repository specify that version string as the provider
 version:
 
 ```hcl
@@ -76,10 +78,11 @@ terraform {
   required_providers {
     stepca = {
       source  = "github.com/z0link/terraform-provider-stepca"
-      version = "<commit>"
+      version = "stepca-<step-version>-<commit>"
     }
   }
 }
 ```
 
-Replace `<commit>` with the hash shown on the GitHub releases page.
+Replace `<step-version>` with the CLI version embedded in the filename and
+`<commit>` with the commit hash shown on the GitHub releases page.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VERSION="${1:-$(git rev-parse --short HEAD)}"
 BINARY="terraform-provider-stepca"
+STEP_VERSION="$(step version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)"
+COMMIT_TAG="$(git tag --points-at HEAD | head -n 1)"
+if [[ -z "$COMMIT_TAG" ]]; then
+  COMMIT_TAG="$(git rev-parse --short=6 HEAD)"
+fi
+VERSION="${1:-stepca-${STEP_VERSION}-${COMMIT_TAG}}"
 DIST_DIR="dist"
 
 echo "Building provider binary..."

--- a/scripts/test_release.sh
+++ b/scripts/test_release.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VERSION="${1:?version required}"
 BINARY="terraform-provider-stepca"
+VERSION="${1:?version required}"
+TEST_VERSION="0.0.0"
 DIST_DIR="dist"
 
 # Build and start dummy CA
@@ -22,7 +23,7 @@ sleep 1
 
 PLUGIN_DIR=$(mktemp -d)
 unzip "$DIST_DIR/${BINARY}_${VERSION}_linux_amd64.zip" -d "$PLUGIN_DIR"
-mv "$PLUGIN_DIR/$BINARY" "$PLUGIN_DIR/${BINARY}_v${VERSION}"
+mv "$PLUGIN_DIR/$BINARY" "$PLUGIN_DIR/${BINARY}_v${TEST_VERSION}"
 
 TMP_DIR=$(mktemp -d)
 cat <<TF > "$TMP_DIR/main.tf"
@@ -30,7 +31,7 @@ terraform {
   required_providers {
     stepca = {
       source  = "local/stepca"
-      version = "${VERSION}"
+      version = "${TEST_VERSION}"
     }
   }
 }


### PR DESCRIPTION
## Summary
- derive provider version from step CLI and commit
- install step-cli and step-ca in the release workflow
- note new version format in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6877f500c4ac832eb186be83cf5451a3