### PR TITLE
Add docs for registry publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This provider aims to expose [step-ca](https://github.com/smallstep/certificates) CLI operations as declarative Terraform resources. It currently offers a simple resource for signing certificates using the `/sign` API endpoint, but will expand to cover more of step-ca's functionality.
 
+Provider documentation for registry publishing is located in the `docs` directory.
+
 ## Project goals
 
 The long-term objective is to manage step-ca configuration statefully through Terraform. Planned capabilities include:

--- a/docs/data-sources/version.md
+++ b/docs/data-sources/version.md
@@ -1,0 +1,13 @@
+# stepca_version
+
+Provides the version string for the running step-ca instance.
+
+## Example Usage
+
+```hcl
+data "stepca_version" "current" {}
+```
+
+## Attributes Reference
+
+* `version` - The step-ca version string.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,36 @@
+# StepCA Provider
+
+Use the **stepca** provider to interact with a [step-ca](https://github.com/smallstep/certificates) Certificate Authority.
+
+## Example Usage
+
+```hcl
+terraform {
+  required_providers {
+    stepca = {
+      source = "github.com/z0link/stepca"
+      version = "0.1.0"
+    }
+  }
+}
+
+provider "stepca" {
+  ca_url = "https://ca.example.com"
+  token  = "<one-time-token>"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `ca_url` - (Required) The base URL of the step-ca instance.
+* `token`  - (Required) The one-time bootstrap token used to authenticate.
+
+## Resources
+
+* [`stepca_certificate`](resources/certificate.md) - Sign a CSR and obtain a certificate.
+
+## Data Sources
+
+* [`stepca_version`](data-sources/version.md) - Retrieve the CA version.

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -1,0 +1,19 @@
+# stepca_certificate
+
+Signs a certificate signing request (CSR) using the step-ca `/sign` API and returns the issued certificate.
+
+## Example Usage
+
+```hcl
+resource "stepca_certificate" "example" {
+  csr = file("example.csr")
+}
+```
+
+## Argument Reference
+
+* `csr` - (Required) The PEM encoded certificate signing request.
+
+## Attributes Reference
+
+* `certificate` - The PEM encoded signed certificate returned by the CA.


### PR DESCRIPTION
## Summary
- add provider docs for Terraform registry
- include resource and data source docs
- mention docs directory in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6877f600bac0832ebd5a3824ca7cb7a7