### PR TITLE
Improve local testing docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SEMVER ?= 0.0.0-$(VERSION)
 
 DIST_DIR := dist
 
-.PHONY: build binary package test release
+.PHONY: build binary package test release install-local
 
 build: package
 
@@ -20,3 +20,9 @@ test:
 
 release:
 	scripts/release.sh $(VERSION)
+
+install-local: package
+	PLUGIN_DIR=$(HOME)/.terraform.d/plugins/registry.terraform.io/local/stepca/$(SEMVER)/linux_amd64; \
+	mkdir -p $$PLUGIN_DIR; \
+	unzip -o $(DIST_DIR)/$(BINARY)_$(VERSION)_linux_amd64.zip -d $$PLUGIN_DIR; \
+	mv $$PLUGIN_DIR/$(BINARY) $$PLUGIN_DIR/$(BINARY)_v$(SEMVER)

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ the provider version:
 terraform {
   required_providers {
     stepca = {
-      source  = "github.com/z0link/terraform-provider-stepca"
+      source  = "registry.terraform.io/local/stepca"
       version = "0.0.0-<commit>"
     }
   }
@@ -97,4 +97,31 @@ terraform {
 ```
 
 Replace `<commit>` with the commit hash shown on the GitHub releases page.
+
+## Using a Local Build
+
+You can test the provider without publishing it to the Terraform Registry.
+Build the provider and place it under Terraform's plugin directory so that
+`terraform init` can discover it.
+
+```
+# Build the binary with an explicit version
+SEMVER=0.1.0 make package
+
+# Install it into Terraform's plugin directory
+make install-local SEMVER=0.1.0
+```
+
+Terraform configurations then reference the local provider source:
+
+```hcl
+terraform {
+  required_providers {
+    stepca = {
+      source  = "registry.terraform.io/local/stepca"
+      version = "0.1.0"
+    }
+  }
+}
+```
 


### PR DESCRIPTION
## Summary
- update provider source in README
- describe how to use a locally built provider
- add `install-local` make target for installing the provider to the Terraform plugin directory

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687a456de344832ea9c8bea2b04a7763