### PR TITLE
Clarify admin token usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ password.txt
 
 # Terraform local data
 .terraform/
+.terraform.lock.hcl
 
 # Go build cache
 *.test

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -19,7 +19,8 @@ Diese Datei sammelt moegliche Terraform **Data Sources** und **Resources** fuer 
 ## Potenzielle Resources
 
 - **stepca_certificate** – Signiert ein CSR und liefert das Zertifikat (bereits vorhanden; Create-only).
-- **stepca_provisioner** – Legt Provisioner an (JWK, OIDC, ACME, X5C, SSHPOP, Cloud usw.), aendert und entfernt sie.
+- **stepca_provisioner** – Legt Provisioner an (JWK, OIDC, ACME, X5C, SSHPOP, Cloud usw.), aendert und entfernt sie. Nach `step ca init` existiert genau ein JWK-Admin-Provisioner. Weitere Admins koennen optional konfiguriert werden.
+- **stepca_admin** – Verwalten einzelner Admin-User und Zuordnung zu Provisionern.
 - **stepca_template** – Erstellt bzw. aktualisiert Zertifikats-Templates aus den Vorlagen der Step-CA Dokumentation.
 - **stepca_policy** – Definiert Issuance Policies, wie in `policies.mdx` beschrieben.
 - **stepca_webhook** – Verwaltung der Webhook-Konfiguration fuer Ereignisse (siehe `webhooks.mdx`).

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ resource "stepca_provisioner" "admin" {
 # Manage an admin
 resource "stepca_admin" "alice" {
   name        = "alice"
-  provisioner = stepca_provisioner.admin.name
+  provisioner_name = stepca_provisioner.admin.name
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The long-term objective is to manage step-ca configuration statefully through Te
 
 * [Go](https://go.dev/) 1.24 or newer must be installed and in your `PATH`.
 * The `terraform` CLI is only required when publishing to the Terraform registry.
+* Install the `step-kms-plugin` so YubiKey-backed keys can be used for the
+  provider's `admin_key`.
 
 ## Building
 
@@ -45,12 +47,42 @@ PUBLISH_TO_TERRAFORM_REGISTRY=true make release VERSION=v0.1.0
 provider "stepca" {
   ca_url = "https://ca.example.com"
   token  = "<one-time-token>"
+  admin_name = "admin@example.com"
+  admin_key  = "/path/to/admin.key"
+  admin_provisioner = "admin"
+  # Supply a token generated for the admin API. When using a JWK admin
+  # provisioner you can create this token with your `admin_key` using
+  # `step ca admin` or `step ca token --issuer <admin_provisioner>`.
+  admin_token = "<admin-token>"
 }
 
 resource "stepca_certificate" "example" {
   csr = file("example.csr")
 }
+
+# Manage a provisioner
+resource "stepca_provisioner" "admin" {
+  name  = "admin"
+  type  = "JWK"
+  admin = true
+}
+
+# Manage an admin
+resource "stepca_admin" "alice" {
+  name        = "alice"
+  provisioner = stepca_provisioner.admin.name
+}
 ```
+
+### Step CA Initialization
+
+After running `step ca init` a single JWK provisioner with admin privileges is
+created. Additional provisioners can be managed via the `stepca_provisioner`
+resource. Use the provider's optional `admin_token` argument with a token issued
+for an existing admin provisioner when creating new ones. Tokens can be
+generated using `step ca admin` or `step ca token --issuer <provisioner>` with
+the corresponding admin key. Set `admin = true` to create another admin
+provisioner if desired.
 
 The resulting certificate will be available as the `certificate` attribute.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,12 @@ terraform {
 provider "stepca" {
   ca_url = "https://ca.example.com"
   token  = "<one-time-token>"
+  admin_name = "admin@example.com"
+  admin_key  = "/path/to/admin.key"
+  admin_provisioner = "admin"
+  # Generate a token for the admin API with `step ca admin` or
+  # `step ca token --issuer ${admin_provisioner}` and provide it here.
+  admin_token = "<admin-token>"
 }
 ```
 
@@ -25,11 +31,23 @@ provider "stepca" {
 The following arguments are supported:
 
 * `ca_url` - (Required) The base URL of the step-ca instance.
+* `admin_name` - (Required) The admin user name.
+* `admin_key` - (Required) Path or KMS URI of the admin private key. Keys on a
+  YubiKey can be referenced via the `step-kms-plugin` URI scheme.
+* `admin_provisioner` - (Optional) Name of the JWK admin provisioner.
 * `token`  - (Required) The one-time bootstrap token used to authenticate.
+* `admin_token` - (Optional) Token used for admin API operations. The CA
+  initialized by `step ca init` includes a single JWK admin provisioner. Use a
+  token issued for that provisioner or another admin to manage resources that
+  require admin privileges. Although `admin_key` is mandatory for
+  authentication, this provider currently expects a pre-generated token rather
+  than generating it automatically.
 
 ## Resources
 
 * [`stepca_certificate`](resources/certificate.md) - Sign a CSR and obtain a certificate.
+* [`stepca_provisioner`](resources/provisioner.md) - Manage provisioners.
+* [`stepca_admin`](resources/admin.md) - Manage admin users.
 
 ## Data Sources
 

--- a/docs/resources/admin.md
+++ b/docs/resources/admin.md
@@ -1,0 +1,28 @@
+# stepca_admin
+
+Manages an admin user via the step-ca admin API.
+
+## Example Usage
+
+```hcl
+resource "stepca_admin" "alice" {
+  name        = "alice"
+  provisioner = "admin"
+}
+```
+
+Use the provider's `admin_token` argument with a token issued for the admin
+provisioner. When using a JWK admin provisioner you can generate this token
+with `step ca admin` or `step ca token` using your `admin_key`.
+
+Admins belong to a specific admin provisioner. Combine this resource with
+`stepca_provisioner` to manage both provisioners and their admins.
+
+## Argument Reference
+
+* `name` - (Required) The admin's name/email.
+* `provisioner` - (Required) Name of the admin provisioner this admin belongs to.
+
+## Attributes Reference
+
+This resource has no additional attributes.

--- a/docs/resources/admin.md
+++ b/docs/resources/admin.md
@@ -6,8 +6,8 @@ Manages an admin user via the step-ca admin API.
 
 ```hcl
 resource "stepca_admin" "alice" {
-  name        = "alice"
-  provisioner = "admin"
+  name             = "alice"
+  provisioner_name = "admin"
 }
 ```
 
@@ -21,7 +21,7 @@ Admins belong to a specific admin provisioner. Combine this resource with
 ## Argument Reference
 
 * `name` - (Required) The admin's name/email.
-* `provisioner` - (Required) Name of the admin provisioner this admin belongs to.
+* `provisioner_name` - (Required) Name of the admin provisioner this admin belongs to.
 
 ## Attributes Reference
 

--- a/docs/resources/provisioner.md
+++ b/docs/resources/provisioner.md
@@ -1,0 +1,32 @@
+# stepca_provisioner
+
+Manages a provisioner through the step-ca admin API.
+
+## Example Usage
+
+```hcl
+resource "stepca_provisioner" "admin" {
+  name  = "admin"
+  type  = "JWK"
+  admin = true
+}
+```
+
+The CA created by `step ca init` includes a default JWK admin provisioner. To
+create additional provisioners you must supply an admin token from an existing
+admin provisioner via the provider's `admin_token` argument. Generate the token
+using `step ca admin` or `step ca token --issuer <provisioner>` with the
+corresponding admin key.
+
+Provisioners marked as `admin = true` can create additional admins with the
+`stepca_admin` resource.
+
+## Argument Reference
+
+* `name` - (Required) Name of the provisioner.
+* `type` - (Required) Provisioner type, e.g. `JWK`, `OIDC`, `ACME`, `X5C`.
+* `admin` - (Optional) Set to `true` to create an admin provisioner.
+
+## Attributes Reference
+
+This resource has no additional attributes.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,13 +10,37 @@ import (
 )
 
 type Client struct {
-	baseURL    string
-	token      string
-	httpClient *http.Client
+	baseURL          string
+	token            string
+	adminName        string
+	adminKey         string
+	adminProvisioner string
+	adminToken       string
+	httpClient       *http.Client
 }
 
 func New(baseURL, token string) *Client {
 	return &Client{baseURL: baseURL, token: token, httpClient: &http.Client{}}
+}
+
+func (c *Client) WithAdminToken(t string) *Client {
+	c.adminToken = t
+	return c
+}
+
+func (c *Client) WithAdminName(name string) *Client {
+	c.adminName = name
+	return c
+}
+
+func (c *Client) WithAdminKey(key string) *Client {
+	c.adminKey = key
+	return c
+}
+
+func (c *Client) WithAdminProvisioner(p string) *Client {
+	c.adminProvisioner = p
+	return c
 }
 
 // Sign sends a CSR to the /sign endpoint and returns the certificate PEM bytes.
@@ -88,4 +112,157 @@ func (c *Client) RootCertificate(ctx context.Context) ([]byte, error) {
 		return nil, err
 	}
 	return b, nil
+}
+
+// Provisioner represents a simple provisioner configuration.
+type Provisioner struct {
+	Name  string `json:"name"`
+	Type  string `json:"type"`
+	Admin bool   `json:"admin,omitempty"`
+}
+
+// CreateProvisioner adds a new provisioner using the admin API.
+func (c *Client) CreateProvisioner(ctx context.Context, p Provisioner) error {
+	b, err := json.Marshal(p)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/admin/provisioners", c.baseURL), bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.adminToken)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	return nil
+}
+
+// DeleteProvisioner removes a provisioner via the admin API.
+func (c *Client) DeleteProvisioner(ctx context.Context, name string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, fmt.Sprintf("%s/admin/provisioners/%s", c.baseURL, name), nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.adminToken)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	return nil
+}
+
+// GetProvisioner retrieves a provisioner by name.
+func (c *Client) GetProvisioner(ctx context.Context, name string) (*Provisioner, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/admin/provisioners/%s", c.baseURL, name), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.adminToken)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	var out Provisioner
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Admin represents an admin user configuration.
+type Admin struct {
+	Name        string `json:"name"`
+	Provisioner string `json:"provisioner"`
+}
+
+// CreateAdmin adds a new admin using the admin API.
+func (c *Client) CreateAdmin(ctx context.Context, a Admin) error {
+	b, err := json.Marshal(a)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fmt.Sprintf("%s/admin/admins", c.baseURL), bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.adminToken)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	return nil
+}
+
+// DeleteAdmin removes an admin via the admin API.
+func (c *Client) DeleteAdmin(ctx context.Context, name, provisioner string) error {
+	path := fmt.Sprintf("%s/admin/admins/%s?provisioner=%s", c.baseURL, name, provisioner)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, path, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.adminToken)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	return nil
+}
+
+// GetAdmin retrieves an admin by name and provisioner.
+func (c *Client) GetAdmin(ctx context.Context, name, provisioner string) (*Admin, error) {
+	path := fmt.Sprintf("%s/admin/admins/%s?provisioner=%s", c.baseURL, name, provisioner)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.adminToken)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	var out Admin
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return &out, nil
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -45,11 +45,11 @@ func (p *stepcaProvider) Schema(ctx context.Context, req provider.SchemaRequest,
 			"admin_key":         schema.StringAttribute{Required: true},
 			"admin_provisioner": schema.StringAttribute{Optional: true},
 			"token":             schema.StringAttribute{Required: true, Sensitive: true},
-                       // Token for admin API calls. Generate with the admin key if
-                       // using a JWK admin provisioner.
-                       "admin_token":       schema.StringAttribute{Optional: true, Sensitive: true},
-               },
-       }
+			// Token for admin API calls. Generate with the admin key if
+			// using a JWK admin provisioner.
+			"admin_token": schema.StringAttribute{Optional: true, Sensitive: true},
+		},
+	}
 }
 
 func (p *stepcaProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -24,8 +24,12 @@ func New() provider.Provider {
 type stepcaProvider struct{}
 
 type stepcaProviderModel struct {
-	CAURL types.String `tfsdk:"ca_url"`
-	Token types.String `tfsdk:"token"`
+	CAURL            types.String `tfsdk:"ca_url"`
+	AdminName        types.String `tfsdk:"admin_name"`
+	AdminKey         types.String `tfsdk:"admin_key"`
+	AdminProvisioner types.String `tfsdk:"admin_provisioner"`
+	Token            types.String `tfsdk:"token"`
+	AdminToken       types.String `tfsdk:"admin_token"`
 }
 
 func (p *stepcaProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -36,10 +40,16 @@ func (p *stepcaProvider) Metadata(ctx context.Context, req provider.MetadataRequ
 func (p *stepcaProvider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"ca_url": schema.StringAttribute{Required: true},
-			"token":  schema.StringAttribute{Required: true, Sensitive: true},
-		},
-	}
+			"ca_url":            schema.StringAttribute{Required: true},
+			"admin_name":        schema.StringAttribute{Required: true},
+			"admin_key":         schema.StringAttribute{Required: true},
+			"admin_provisioner": schema.StringAttribute{Optional: true},
+			"token":             schema.StringAttribute{Required: true, Sensitive: true},
+                       // Token for admin API calls. Generate with the admin key if
+                       // using a JWK admin provisioner.
+                       "admin_token":       schema.StringAttribute{Optional: true, Sensitive: true},
+               },
+       }
 }
 
 func (p *stepcaProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
@@ -51,6 +61,14 @@ func (p *stepcaProvider) Configure(ctx context.Context, req provider.ConfigureRe
 	}
 
 	c := client.New(data.CAURL.ValueString(), data.Token.ValueString())
+	c = c.WithAdminName(data.AdminName.ValueString())
+	c = c.WithAdminKey(data.AdminKey.ValueString())
+	if !data.AdminProvisioner.IsNull() {
+		c = c.WithAdminProvisioner(data.AdminProvisioner.ValueString())
+	}
+	if !data.AdminToken.IsNull() {
+		c = c.WithAdminToken(data.AdminToken.ValueString())
+	}
 	resp.DataSourceData = c
 	resp.ResourceData = c
 }
@@ -58,6 +76,8 @@ func (p *stepcaProvider) Configure(ctx context.Context, req provider.ConfigureRe
 func (p *stepcaProvider) Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewCertificateResource,
+		NewProvisionerResource,
+		NewAdminResource,
 	}
 }
 

--- a/internal/provider/resource_admin.go
+++ b/internal/provider/resource_admin.go
@@ -1,0 +1,125 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/z0link/terraform-provider-stepca/internal/client"
+)
+
+var _ resource.Resource = &adminResource{}
+
+func NewAdminResource() resource.Resource { return &adminResource{} }
+
+type adminResource struct{ client *client.Client }
+
+type adminResourceModel struct {
+	Name        types.String `tfsdk:"name"`
+	Provisioner types.String `tfsdk:"provisioner"`
+}
+
+func (r *adminResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "stepca_admin"
+}
+
+func (r *adminResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name":        schema.StringAttribute{Required: true},
+			"provisioner": schema.StringAttribute{Required: true},
+		},
+	}
+}
+
+func (r *adminResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	if c, ok := req.ProviderData.(*client.Client); ok {
+		r.client = c
+	}
+}
+
+func (r *adminResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data adminResourceModel
+	diags := req.Plan.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client == nil {
+		resp.Diagnostics.AddError("provider not configured", "missing client")
+		return
+	}
+	a := client.Admin{Name: data.Name.ValueString(), Provisioner: data.Provisioner.ValueString()}
+	if err := r.client.CreateAdmin(ctx, a); err != nil {
+		resp.Diagnostics.AddError("create failed", err.Error())
+		return
+	}
+	diags = resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *adminResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data adminResourceModel
+	diags := req.State.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client == nil {
+		resp.Diagnostics.AddError("provider not configured", "missing client")
+		return
+	}
+	a, err := r.client.GetAdmin(ctx, data.Name.ValueString(), data.Provisioner.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("read failed", err.Error())
+		return
+	}
+	if a == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	diags = resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *adminResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data adminResourceModel
+	diags := req.Plan.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client == nil {
+		resp.Diagnostics.AddError("provider not configured", "missing client")
+		return
+	}
+	a := client.Admin{Name: data.Name.ValueString(), Provisioner: data.Provisioner.ValueString()}
+	if err := r.client.CreateAdmin(ctx, a); err != nil {
+		resp.Diagnostics.AddError("update failed", err.Error())
+		return
+	}
+	diags = resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *adminResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data adminResourceModel
+	diags := req.State.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client == nil {
+		resp.Diagnostics.AddError("provider not configured", "missing client")
+		return
+	}
+	if err := r.client.DeleteAdmin(ctx, data.Name.ValueString(), data.Provisioner.ValueString()); err != nil {
+		resp.Diagnostics.AddError("delete failed", err.Error())
+		return
+	}
+}

--- a/internal/provider/resource_admin.go
+++ b/internal/provider/resource_admin.go
@@ -17,8 +17,8 @@ func NewAdminResource() resource.Resource { return &adminResource{} }
 type adminResource struct{ client *client.Client }
 
 type adminResourceModel struct {
-	Name        types.String `tfsdk:"name"`
-	Provisioner types.String `tfsdk:"provisioner"`
+	Name            types.String `tfsdk:"name"`
+	ProvisionerName types.String `tfsdk:"provisioner_name"`
 }
 
 func (r *adminResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -54,7 +54,7 @@ func (r *adminResource) Create(ctx context.Context, req resource.CreateRequest, 
 		resp.Diagnostics.AddError("provider not configured", "missing client")
 		return
 	}
-	a := client.Admin{Name: data.Name.ValueString(), Provisioner: data.Provisioner.ValueString()}
+	a := client.Admin{Name: data.Name.ValueString(), Provisioner: data.ProvisionerName.ValueString()}
 	if err := r.client.CreateAdmin(ctx, a); err != nil {
 		resp.Diagnostics.AddError("create failed", err.Error())
 		return
@@ -74,7 +74,7 @@ func (r *adminResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		resp.Diagnostics.AddError("provider not configured", "missing client")
 		return
 	}
-	a, err := r.client.GetAdmin(ctx, data.Name.ValueString(), data.Provisioner.ValueString())
+	a, err := r.client.GetAdmin(ctx, data.Name.ValueString(), data.ProvisionerName.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("read failed", err.Error())
 		return
@@ -98,7 +98,7 @@ func (r *adminResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		resp.Diagnostics.AddError("provider not configured", "missing client")
 		return
 	}
-	a := client.Admin{Name: data.Name.ValueString(), Provisioner: data.Provisioner.ValueString()}
+	a := client.Admin{Name: data.Name.ValueString(), Provisioner: data.ProvisionerName.ValueString()}
 	if err := r.client.CreateAdmin(ctx, a); err != nil {
 		resp.Diagnostics.AddError("update failed", err.Error())
 		return
@@ -118,7 +118,7 @@ func (r *adminResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		resp.Diagnostics.AddError("provider not configured", "missing client")
 		return
 	}
-	if err := r.client.DeleteAdmin(ctx, data.Name.ValueString(), data.Provisioner.ValueString()); err != nil {
+	if err := r.client.DeleteAdmin(ctx, data.Name.ValueString(), data.ProvisionerName.ValueString()); err != nil {
 		resp.Diagnostics.AddError("delete failed", err.Error())
 		return
 	}

--- a/internal/provider/resource_provisioner.go
+++ b/internal/provider/resource_provisioner.go
@@ -1,0 +1,133 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/z0link/terraform-provider-stepca/internal/client"
+)
+
+var _ resource.Resource = &provisionerResource{}
+
+func NewProvisionerResource() resource.Resource {
+	return &provisionerResource{}
+}
+
+type provisionerResource struct {
+	client *client.Client
+}
+
+type provisionerResourceModel struct {
+	Name  types.String `tfsdk:"name"`
+	Type  types.String `tfsdk:"type"`
+	Admin types.Bool   `tfsdk:"admin"`
+}
+
+func (r *provisionerResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "stepca_provisioner"
+}
+
+func (r *provisionerResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name":  schema.StringAttribute{Required: true},
+			"type":  schema.StringAttribute{Required: true},
+			"admin": schema.BoolAttribute{Optional: true},
+		},
+	}
+}
+
+func (r *provisionerResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	if c, ok := req.ProviderData.(*client.Client); ok {
+		r.client = c
+	}
+}
+
+func (r *provisionerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data provisionerResourceModel
+	diags := req.Plan.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client == nil {
+		resp.Diagnostics.AddError("provider not configured", "missing client")
+		return
+	}
+	p := client.Provisioner{Name: data.Name.ValueString(), Type: data.Type.ValueString(), Admin: !data.Admin.IsNull() && data.Admin.ValueBool()}
+	if err := r.client.CreateProvisioner(ctx, p); err != nil {
+		resp.Diagnostics.AddError("create failed", err.Error())
+		return
+	}
+	diags = resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *provisionerResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data provisionerResourceModel
+	diags := req.State.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client == nil {
+		resp.Diagnostics.AddError("provider not configured", "missing client")
+		return
+	}
+	p, err := r.client.GetProvisioner(ctx, data.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("read failed", err.Error())
+		return
+	}
+	if p == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	data.Type = types.StringValue(p.Type)
+	data.Admin = types.BoolValue(p.Admin)
+	diags = resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *provisionerResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data provisionerResourceModel
+	diags := req.Plan.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client == nil {
+		resp.Diagnostics.AddError("provider not configured", "missing client")
+		return
+	}
+	p := client.Provisioner{Name: data.Name.ValueString(), Type: data.Type.ValueString(), Admin: !data.Admin.IsNull() && data.Admin.ValueBool()}
+	if err := r.client.CreateProvisioner(ctx, p); err != nil {
+		resp.Diagnostics.AddError("update failed", err.Error())
+		return
+	}
+	diags = resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *provisionerResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data provisionerResourceModel
+	diags := req.State.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client == nil {
+		resp.Diagnostics.AddError("provider not configured", "missing client")
+		return
+	}
+	if err := r.client.DeleteProvisioner(ctx, data.Name.ValueString()); err != nil {
+		resp.Diagnostics.AddError("delete failed", err.Error())
+		return
+	}
+}


### PR DESCRIPTION
## Summary
- expand README with details on generating admin tokens
- document token generation in provider docs
- mention provisioning/admin cross-usage in resource docs
- note that provider expects a pre-generated admin token

## Testing
- `make test`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687a7082b708832ea8181e73ab4d0f12