### PR TITLE
Fix admin resource schema and add unit test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/z0link/terraform-provider-stepca
 
 go 1.24.3
 
-require github.com/hashicorp/terraform-plugin-framework v1.15.0
+require (
+	github.com/google/go-cmp v0.7.0
+	github.com/hashicorp/terraform-plugin-framework v1.15.0
+)
 
 require (
 	github.com/fatih/color v1.16.0 // indirect

--- a/internal/provider/resource_admin.go
+++ b/internal/provider/resource_admin.go
@@ -28,8 +28,8 @@ func (r *adminResource) Metadata(ctx context.Context, req resource.MetadataReque
 func (r *adminResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"name":        schema.StringAttribute{Required: true},
-			"provisioner": schema.StringAttribute{Required: true},
+			"name":             schema.StringAttribute{Required: true},
+			"provisioner_name": schema.StringAttribute{Required: true},
 		},
 	}
 }
@@ -83,6 +83,8 @@ func (r *adminResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		resp.State.RemoveResource(ctx)
 		return
 	}
+	data.Name = types.StringValue(a.Name)
+	data.ProvisionerName = types.StringValue(a.Provisioner)
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 }

--- a/internal/provider/resource_admin_test.go
+++ b/internal/provider/resource_admin_test.go
@@ -1,0 +1,29 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	pfresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+func TestAdminResourceSchema(t *testing.T) {
+	t.Parallel()
+
+	resource := NewAdminResource()
+	var resp pfresource.SchemaResponse
+	resource.Schema(context.Background(), pfresource.SchemaRequest{}, &resp)
+
+	expected := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name":             schema.StringAttribute{Required: true},
+			"provisioner_name": schema.StringAttribute{Required: true},
+		},
+	}
+
+	if diff := cmp.Diff(expected, resp.Schema); diff != "" {
+		t.Fatalf("unexpected schema: (-want +got)\n%s", diff)
+	}
+}


### PR DESCRIPTION
## Summary
- expose the `provisioner_name` attribute in the admin resource schema and persist refreshed state data during Read
- add a schema unit test that validates the attribute definitions and introduce go-cmp for comparisons

## Testing
- `go test ./...`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a4496c2a8832e8342a1e8144cd815)