### PR TITLE
Add provisioners data source

### DIFF
--- a/docs/data-sources/provisioners.md
+++ b/docs/data-sources/provisioners.md
@@ -1,0 +1,31 @@
+---
+page_title: "stepca_provisioners Data Source"
+subcategory: "Provisioners"
+description: |-
+  Retrieve the provisioners configured in a step-ca instance via the admin API.
+---
+
+# stepca_provisioners (Data Source)
+
+Use this data source to list every provisioner that the authenticated admin can access. The resulting list exposes the provisioner name, type, and whether the provisioner has admin privileges.
+
+## Example Usage
+
+```hcl
+data "stepca_provisioners" "all" {}
+
+output "admin_provisioners" {
+  value = [for p in data.stepca_provisioners.all.provisioners : p if p.admin]
+}
+```
+
+## Argument Reference
+
+This data source does not take any arguments.
+
+## Attributes Reference
+
+* `provisioners` - List of provisioners returned by the admin API. Each entry exports the following attributes:
+  * `name` - Provisioner name.
+  * `type` - Provisioner type (for example `JWK`, `ACME`, or `OIDC`).
+  * `admin` - Boolean indicating whether the provisioner is flagged as an admin provisioner.

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,3 +53,4 @@ The following arguments are supported:
 
 * [`stepca_version`](data-sources/version.md) - Retrieve the CA version.
 * [`stepca_ca_certificate`](data-sources/ca_certificate.md) - Fetch the root certificate.
+* [`stepca_provisioners`](data-sources/provisioners.md) - List provisioners via the admin API.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -121,6 +121,28 @@ type Provisioner struct {
 	Admin bool   `json:"admin,omitempty"`
 }
 
+// ListProvisioners retrieves all provisioners available via the admin API.
+func (c *Client) ListProvisioners(ctx context.Context) ([]Provisioner, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/admin/provisioners", c.baseURL), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.adminToken)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected status: %s", resp.Status)
+	}
+	var out []Provisioner
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // CreateProvisioner adds a new provisioner using the admin API.
 func (c *Client) CreateProvisioner(ctx context.Context, p Provisioner) error {
 	b, err := json.Marshal(p)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"reflect"
 	"testing"
 )
 
@@ -218,5 +220,50 @@ func TestClientAdmin(t *testing.T) {
 
 	if err := c.DeleteAdmin(context.Background(), "alice", "admin"); err != nil {
 		t.Fatalf("delete failed: %v", err)
+	}
+}
+
+func TestClientListProvisioners(t *testing.T) {
+fixture, err := os.ReadFile("testdata/provisioners.json")
+	if err != nil {
+		t.Fatalf("failed to read fixture: %v", err)
+	}
+	var expected []Provisioner
+	if err := json.Unmarshal(fixture, &expected); err != nil {
+		t.Fatalf("failed to unmarshal fixture: %v", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/admin/provisioners" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(fixture)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "token").WithAdminToken("admin")
+	c.httpClient = srv.Client()
+
+	got, err := c.ListProvisioners(context.Background())
+	if err != nil {
+		t.Fatalf("ListProvisioners returned error: %v", err)
+	}
+	if !reflect.DeepEqual(expected, got) {
+		t.Fatalf("unexpected provisioners: %#v", got)
+	}
+
+	errSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer errSrv.Close()
+
+	c = New(errSrv.URL, "token").WithAdminToken("admin")
+	c.httpClient = errSrv.Client()
+	if _, err := c.ListProvisioners(context.Background()); err == nil {
+		t.Fatal("expected error from ListProvisioners")
 	}
 }

--- a/internal/client/testdata/provisioners.json
+++ b/internal/client/testdata/provisioners.json
@@ -1,0 +1,5 @@
+[
+  {"name": "bootstrap-admin", "type": "JWK", "admin": true},
+  {"name": "acme", "type": "ACME", "admin": false},
+  {"name": "device", "type": "X5C", "admin": false}
+]

--- a/internal/provider/data_source_provisioners.go
+++ b/internal/provider/data_source_provisioners.go
@@ -1,0 +1,86 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/z0link/terraform-provider-stepca/internal/client"
+)
+
+var _ datasource.DataSource = &provisionersDataSource{}
+
+func NewProvisionersDataSource() datasource.DataSource {
+	return &provisionersDataSource{}
+}
+
+type provisionersDataSource struct {
+	client *client.Client
+}
+
+type provisionersDataSourceModel struct {
+	Provisioners []provisionerItemModel `tfsdk:"provisioners"`
+}
+
+type provisionerItemModel struct {
+	Name  types.String `tfsdk:"name"`
+	Type  types.String `tfsdk:"type"`
+	Admin types.Bool   `tfsdk:"admin"`
+}
+
+func (d *provisionersDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "stepca_provisioners"
+}
+
+func (d *provisionersDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"provisioners": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name":  schema.StringAttribute{Computed: true},
+						"type":  schema.StringAttribute{Computed: true},
+						"admin": schema.BoolAttribute{Computed: true},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *provisionersDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	if c, ok := req.ProviderData.(*client.Client); ok {
+		d.client = c
+	}
+}
+
+func (d *provisionersDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	if d.client == nil {
+		resp.Diagnostics.AddError("provider not configured", "missing client")
+		return
+	}
+
+	items, err := d.client.ListProvisioners(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to list provisioners", err.Error())
+		return
+	}
+
+	data := provisionersDataSourceModel{Provisioners: make([]provisionerItemModel, 0, len(items))}
+	for _, item := range items {
+		data.Provisioners = append(data.Provisioners, provisionerItemModel{
+			Name:  types.StringValue(item.Name),
+			Type:  types.StringValue(item.Type),
+			Admin: types.BoolValue(item.Admin),
+		})
+	}
+
+	diags := resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -82,8 +82,9 @@ func (p *stepcaProvider) Resources(ctx context.Context) []func() resource.Resour
 }
 
 func (p *stepcaProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
-	return []func() datasource.DataSource{
-		NewVersionDataSource,
-		NewCACertificateDataSource,
-	}
+        return []func() datasource.DataSource{
+                NewVersionDataSource,
+                NewCACertificateDataSource,
+                NewProvisionersDataSource,
+        }
 }


### PR DESCRIPTION
## Summary
- add an admin ListProvisioners helper to the client along with fixture-backed tests
- expose a new `stepca_provisioners` data source and document its usage

## Testing
- `go test ./...`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a44b3b594832e9a156b057537486b)