### PR TITLE
Handle certificate refresh and deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,12 @@ generated using `step ca admin` or `step ca token --issuer <provisioner>` with
 the corresponding admin key. Set `admin = true` to create another admin
 provisioner if desired.
 
-The resulting certificate will be available as the `certificate` attribute.
+The resulting certificate will be available as the `certificate` attribute. The
+resource is create-only: deleting it in Terraform simply forgets the stored
+certificate, and any required revocation must be performed directly in
+step-ca. During refreshes the provider re-fetches the certificate by serial
+number and removes it from state if the CA reports it has been revoked or
+replaced.
 
 ### Data Sources
 

--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -17,3 +17,12 @@ resource "stepca_certificate" "example" {
 ## Attributes Reference
 
 * `certificate` - The PEM encoded signed certificate returned by the CA.
+
+## Behavior
+
+`stepca_certificate` is a create-only resource. Terraform stores the issued
+certificate in state so it can be referenced elsewhere, but it cannot update or
+revoke the certificate in the CA. The provider re-reads the certificate by
+serial number when possible and removes it from state if the CA reports it has
+been revoked or replaced. Running `terraform destroy` deletes the resource from
+state only; you must revoke the certificate manually if necessary.

--- a/internal/provider/resource_certificate.go
+++ b/internal/provider/resource_certificate.go
@@ -1,8 +1,14 @@
 package provider
 
 import (
+	"bytes"
 	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -16,8 +22,13 @@ func NewCertificateResource() resource.Resource {
 	return &certificateResource{}
 }
 
+type certificateClient interface {
+	Sign(ctx context.Context, csr string) ([]byte, error)
+	Certificate(ctx context.Context, serial string) ([]byte, bool, error)
+}
+
 type certificateResource struct {
-	client *client.Client
+	client certificateClient
 }
 
 type certificateResourceModel struct {
@@ -70,8 +81,99 @@ func (r *certificateResource) Create(ctx context.Context, req resource.CreateReq
 }
 
 func (r *certificateResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data certificateResourceModel
+	diags := req.State.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	keep, readDiags := r.shouldKeepCertificate(ctx, &data)
+	resp.Diagnostics.Append(readDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !keep {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	diags = resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
 }
+
 func (r *certificateResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 }
+
 func (r *certificateResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	resp.State.RemoveResource(ctx)
+}
+
+func (r *certificateResource) shouldKeepCertificate(ctx context.Context, data *certificateResourceModel) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if data.Cert.IsNull() || data.Cert.IsUnknown() || data.Cert.ValueString() == "" {
+		diags = append(diags, diag.NewWarningDiagnostic(
+			"certificate missing",
+			"The certificate value is empty in state. Removing it so Terraform can request a new certificate.",
+		))
+		return false, diags
+	}
+
+	if r.client == nil {
+		return true, diags
+	}
+
+	cert, err := parseCertificate(data.Cert.ValueString())
+	if err != nil {
+		diags = append(diags, diag.NewWarningDiagnostic(
+			"certificate parse failed",
+			fmt.Sprintf("The stored certificate could not be parsed (%v). Removing it so Terraform can recreate the resource.", err),
+		))
+		return false, diags
+	}
+
+	serial := strings.ToLower(cert.SerialNumber.Text(16))
+	remotePEM, found, err := r.client.Certificate(ctx, serial)
+	if err != nil {
+		diags = append(diags, diag.NewErrorDiagnostic("certificate lookup failed", err.Error()))
+		return true, diags
+	}
+
+	if !found {
+		diags = append(diags, diag.NewWarningDiagnostic(
+			"certificate revoked",
+			"The certificate could not be located via the CA API. Removing it from state so Terraform can issue a new one.",
+		))
+		return false, diags
+	}
+
+	remoteCert, err := parseCertificate(string(remotePEM))
+	if err != nil {
+		diags = append(diags, diag.NewErrorDiagnostic("certificate parse failed", err.Error()))
+		return true, diags
+	}
+
+	if !bytes.Equal(remoteCert.Raw, cert.Raw) {
+		diags = append(diags, diag.NewWarningDiagnostic(
+			"certificate drift detected",
+			"The CA returned a different certificate for the stored serial number. Removing it from state so Terraform can request a new certificate.",
+		))
+		return false, diags
+	}
+
+	return true, diags
+}
+
+func parseCertificate(pemData string) (*x509.Certificate, error) {
+	block, _ := pem.Decode([]byte(pemData))
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode certificate PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	return cert, nil
 }

--- a/internal/provider/resource_certificate_test.go
+++ b/internal/provider/resource_certificate_test.go
@@ -1,0 +1,176 @@
+package provider
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type fakeCertificateClient struct {
+	t      *testing.T
+	serial string
+	pem    string
+	found  bool
+	err    error
+}
+
+func (f *fakeCertificateClient) Sign(ctx context.Context, csr string) ([]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeCertificateClient) Certificate(ctx context.Context, serial string) ([]byte, bool, error) {
+	if f.t != nil && f.serial != "" && serial != f.serial {
+		f.t.Fatalf("unexpected serial: %s", serial)
+	}
+	if f.err != nil {
+		return nil, false, f.err
+	}
+	if !f.found {
+		return nil, false, nil
+	}
+	return []byte(f.pem), true, nil
+}
+
+func TestCertificateResourceShouldKeepCertificate(t *testing.T) {
+	t.Parallel()
+
+	certOne := testCertificate(t, 1, "one.test")
+	certTwo := testCertificate(t, 2, "two.test")
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		resource      *certificateResource
+		certValue     types.String
+		wantKeep      bool
+		wantWarnCount int
+	}{
+		{
+			name:          "missing certificate",
+			resource:      &certificateResource{},
+			certValue:     types.StringNull(),
+			wantKeep:      false,
+			wantWarnCount: 1,
+		},
+		{
+			name:          "invalid certificate",
+			resource:      &certificateResource{client: &fakeCertificateClient{}},
+			certValue:     types.StringValue("not-pem"),
+			wantKeep:      false,
+			wantWarnCount: 1,
+		},
+		{
+			name:          "no client keeps state",
+			resource:      &certificateResource{},
+			certValue:     types.StringValue(certOne),
+			wantKeep:      true,
+			wantWarnCount: 0,
+		},
+		{
+			name: "revoked certificate",
+			resource: &certificateResource{
+				client: &fakeCertificateClient{
+					t:      t,
+					serial: serialFromCert(t, certOne),
+					found:  false,
+				},
+			},
+			certValue:     types.StringValue(certOne),
+			wantKeep:      false,
+			wantWarnCount: 1,
+		},
+		{
+			name: "drift detected",
+			resource: &certificateResource{
+				client: &fakeCertificateClient{
+					t:      t,
+					serial: serialFromCert(t, certOne),
+					found:  true,
+					pem:    certTwo,
+				},
+			},
+			certValue:     types.StringValue(certOne),
+			wantKeep:      false,
+			wantWarnCount: 1,
+		},
+		{
+			name: "certificate matches",
+			resource: &certificateResource{
+				client: &fakeCertificateClient{
+					t:      t,
+					serial: serialFromCert(t, certOne),
+					found:  true,
+					pem:    certOne,
+				},
+			},
+			certValue:     types.StringValue(certOne),
+			wantKeep:      true,
+			wantWarnCount: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data := certificateResourceModel{Cert: tc.certValue}
+			keep, diags := tc.resource.shouldKeepCertificate(ctx, &data)
+			if keep != tc.wantKeep {
+				t.Fatalf("expected keep=%t got %t", tc.wantKeep, keep)
+			}
+			warnCount := 0
+			for _, d := range diags {
+				if d.Severity() == diag.SeverityWarning {
+					warnCount++
+				}
+			}
+			if warnCount != tc.wantWarnCount {
+				t.Fatalf("expected %d warnings got %d", tc.wantWarnCount, warnCount)
+			}
+		})
+	}
+}
+
+func testCertificate(t *testing.T, serial int64, cn string) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(serial),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, priv.Public(), priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+func serialFromCert(t *testing.T, pemData string) string {
+	t.Helper()
+	block, _ := pem.Decode([]byte(pemData))
+	if block == nil {
+		t.Fatalf("failed to decode pem data")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse cert: %v", err)
+	}
+	return strings.ToLower(cert.SerialNumber.Text(16))
+}

--- a/scripts/dummy_ca.go
+++ b/scripts/dummy_ca.go
@@ -5,6 +5,27 @@ import (
 	"net/http"
 )
 
+const dummyCertificateSerial = "1"
+const dummyCertificatePEM = `-----BEGIN CERTIFICATE-----
+MIIC3DCCAcSgAwIBAgIBATANBgkqhkiG9w0BAQsFADAWMRQwEgYDVQQDEwtkdW1t
+eS5sb2NhbDAeFw0yNTExMTYyMDQ0MjJaFw0yNjExMTYyMTQ0MjJaMBYxFDASBgNV
+BAMTC2R1bW15LmxvY2FsMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA
+3AQdtoqg/gsuz1SC7Q4Ej435Ru8jGz6VbtLbQBUzVQ8N+UxYX3OhYhpFgID4XGKw
+8Lcq1ZnsgMGW1lTD+V1icwiUxpPQGTHXyj4Y0j8ZNbD581Nl5cdU+1idljk0bXaG
+Uv2PJ7IgI70inUXRfIC3iaTODUI9deInCp/OJbxLaUD2xYoc4cTEEcNnhZ6VDICA
+X2hT5nfEVSoE1iupQjwHhDEAWJ+1nr6KAmYHUn5imrJOJtS+wOl+qjUD2ytcPCjU
+9zKDl6QuftfiQaV7nv9HJQGfN6gypnErk/aZ1FfuJEoxllmjH5yyGEcRAXUBN7pb
+o8QmjNhCBy3Y6CxCA3BDYwIDAQABozUwMzAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0l
+BAwwCgYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADANBgkqhkiG9w0BAQsFAAOCAQEA
+CgGD5HyPork/2Tlol5jw63fUqFQmT70pDTwk9CFYjcNFloKimCGKI/ZwSl9hwmai
+h1MLzJ+XxzMQS9WYAVddZNQ8Odz0URv4RccnyMWdonF/bqC4Roo6Yg1/2kXBX/Ab
+Bu0HvVxEl2A3R3hPxxlCHk5E2etUX7ypASSpJdC7suKYfnVrLpBGJvYTAlynjDUV
+7GC6lyggtK9eLYrFNGGzIJorlcldgzEMjokE8+lxG44CKxzribD4X+dMO010OizK
+D4PQdtDGBYKwgZfRNwbffscpgVL8jIYJYP/TZ35gwYKjRmOWozTAXzT679GtOuGf
+VaUbNVhtYshJXaMN0aTS/w==
+-----END CERTIFICATE-----
+`
+
 func main() {
 	http.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("1.2.3"))
@@ -17,7 +38,11 @@ func main() {
 			OTT string `json:"ott"`
 		}
 		_ = json.NewDecoder(r.Body).Decode(&req)
-		_ = json.NewEncoder(w).Encode(map[string]string{"crt": "dummy-certificate"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"crt": dummyCertificatePEM})
+	})
+
+	http.HandleFunc("/certificates/"+dummyCertificateSerial, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(dummyCertificatePEM))
 	})
 
 	http.ListenAndServe(":8080", nil)

--- a/scripts/test_release.sh
+++ b/scripts/test_release.sh
@@ -68,7 +68,6 @@ cert=$(cd "$TMP_DIR" && terraform output -raw cert)
 
 declare -A tests=(
   ["version"]="1.2.3"
-  ["cert"]="dummy-certificate"
 )
 
 for key in "${!tests[@]}"; do
@@ -79,6 +78,11 @@ for key in "${!tests[@]}"; do
     exit 1
   fi
 done
+
+if [[ "$cert" != *"BEGIN CERTIFICATE"* ]]; then
+  echo "certificate output did not contain a PEM block"
+  exit 1
+fi
 
 echo "Integration tests passed."
 


### PR DESCRIPTION
## Summary
- implement a full Read/Delete flow for `stepca_certificate` that preserves state, checks `/certificates/{serial}` for drift or revocation, and removes state when appropriate
- add the client helper, dummy CA/test release support, documentation about the create-only behavior, and resource/unit tests covering the new logic

## Testing
- `go test ./...`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a44b0c30c832ebff6f914c47f9a7b)