### PR TITLE
Support certificate rotation updates

### DIFF
--- a/docs/resources/certificate.md
+++ b/docs/resources/certificate.md
@@ -13,6 +13,7 @@ resource "stepca_certificate" "example" {
 ## Argument Reference
 
 * `csr` - (Required) The PEM encoded certificate signing request.
+* `force_rotate` - (Optional) Toggle this boolean value to force Terraform to request a fresh certificate without changing the CSR. The value itself is persisted in state so flipping it between `true` and `false` will trigger a new issuance.
 
 ## Attributes Reference
 
@@ -20,9 +21,10 @@ resource "stepca_certificate" "example" {
 
 ## Behavior
 
-`stepca_certificate` is a create-only resource. Terraform stores the issued
-certificate in state so it can be referenced elsewhere, but it cannot update or
-revoke the certificate in the CA. The provider re-reads the certificate by
-serial number when possible and removes it from state if the CA reports it has
-been revoked or replaced. Running `terraform destroy` deletes the resource from
-state only; you must revoke the certificate manually if necessary.
+`stepca_certificate` stores the issued certificate in state so it can be
+referenced elsewhere. When the CSR changes or the `force_rotate` flag is
+toggled, the provider sends the CSR to `/sign` again and overwrites the stored
+certificate. The provider also re-reads the certificate by serial number when
+possible and removes it from state if the CA reports it has been revoked or
+replaced. Running `terraform destroy` deletes the resource from state only; you
+must revoke the certificate manually if necessary.


### PR DESCRIPTION
## Summary
- add a `force_rotate` flag to `stepca_certificate` so new CSRs can be issued without editing the CSR payload
- teach the resource update path to compare plan vs. state and call the `/sign` API whenever the CSR or rotation flag changes
- document the new attribute and cover the behaviour with focused unit tests

## Testing
- `go test ./...`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691af591d32c832eb3436409c000b77e)