### PR TITLE
Allow admin token-only configuration

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,12 +17,12 @@ terraform {
 provider "stepca" {
   ca_url = "https://ca.example.com"
   token  = "<one-time-token>"
-  admin_name = "admin@example.com"
-  admin_key  = "/path/to/admin.key"
   admin_provisioner = "admin"
-  # Generate a token for the admin API with `step ca admin` or
-  # `step ca token --issuer ${admin_provisioner}` and provide it here.
-  admin_token = "<admin-token>"
+
+  # Provide either an admin token or the key pair.
+  # admin_token = "<admin-token>"
+  # admin_name  = "admin@example.com"
+  # admin_key   = "/path/to/admin.key"
 }
 ```
 
@@ -31,17 +31,19 @@ provider "stepca" {
 The following arguments are supported:
 
 * `ca_url` - (Required) The base URL of the step-ca instance.
-* `admin_name` - (Required) The admin user name.
-* `admin_key` - (Required) Path or KMS URI of the admin private key. Keys on a
-  YubiKey can be referenced via the `step-kms-plugin` URI scheme.
+* `admin_name` - (Optional) The admin user name. Required when setting
+  `admin_key`.
+* `admin_key` - (Optional) Path or KMS URI of the admin private key. Keys on a
+  YubiKey can be referenced via the `step-kms-plugin` URI scheme. Required when
+  setting `admin_name`.
 * `admin_provisioner` - (Optional) Name of the JWK admin provisioner.
 * `token`  - (Required) The one-time bootstrap token used to authenticate.
 * `admin_token` - (Optional) Token used for admin API operations. The CA
   initialized by `step ca init` includes a single JWK admin provisioner. Use a
   token issued for that provisioner or another admin to manage resources that
-  require admin privileges. Although `admin_key` is mandatory for
-  authentication, this provider currently expects a pre-generated token rather
-  than generating it automatically.
+  require admin privileges, or provide `admin_name`/`admin_key` so Terraform can
+  mint its own tokens. The provider will emit a configuration error if neither
+  an admin token nor the key pair is supplied.
 
 ## Resources
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -41,8 +42,8 @@ func (p *stepcaProvider) Schema(ctx context.Context, req provider.SchemaRequest,
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"ca_url":            schema.StringAttribute{Required: true},
-			"admin_name":        schema.StringAttribute{Required: true},
-			"admin_key":         schema.StringAttribute{Required: true},
+			"admin_name":        schema.StringAttribute{Optional: true},
+			"admin_key":         schema.StringAttribute{Optional: true},
 			"admin_provisioner": schema.StringAttribute{Optional: true},
 			"token":             schema.StringAttribute{Required: true, Sensitive: true},
 			// Token for admin API calls. Generate with the admin key if
@@ -60,32 +61,64 @@ func (p *stepcaProvider) Configure(ctx context.Context, req provider.ConfigureRe
 		return
 	}
 
+	credDiags := validateAdminCredentials(&data)
+	resp.Diagnostics.Append(credDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	c := client.New(data.CAURL.ValueString(), data.Token.ValueString())
-	c = c.WithAdminName(data.AdminName.ValueString())
-	c = c.WithAdminKey(data.AdminKey.ValueString())
-	if !data.AdminProvisioner.IsNull() {
+	if !data.AdminName.IsNull() && !data.AdminName.IsUnknown() {
+		c = c.WithAdminName(data.AdminName.ValueString())
+	}
+	if !data.AdminKey.IsNull() && !data.AdminKey.IsUnknown() {
+		c = c.WithAdminKey(data.AdminKey.ValueString())
+	}
+	if !data.AdminProvisioner.IsNull() && !data.AdminProvisioner.IsUnknown() {
 		c = c.WithAdminProvisioner(data.AdminProvisioner.ValueString())
 	}
-	if !data.AdminToken.IsNull() {
+	if !data.AdminToken.IsNull() && !data.AdminToken.IsUnknown() {
 		c = c.WithAdminToken(data.AdminToken.ValueString())
 	}
 	resp.DataSourceData = c
 	resp.ResourceData = c
 }
 
+func validateAdminCredentials(data *stepcaProviderModel) diag.Diagnostics {
+	var diags diag.Diagnostics
+	adminNameSet := !data.AdminName.IsNull() && !data.AdminName.IsUnknown()
+	adminKeySet := !data.AdminKey.IsNull() && !data.AdminKey.IsUnknown()
+	adminTokenSet := !data.AdminToken.IsNull() && !data.AdminToken.IsUnknown()
+
+	if adminNameSet != adminKeySet {
+		diags.AddError(
+			"incomplete admin key configuration",
+			"admin_name and admin_key must be set together when not supplying admin_token",
+		)
+		return diags
+	}
+	if !adminTokenSet && !(adminNameSet && adminKeySet) {
+		diags.AddError(
+			"missing admin credentials",
+			"configure either admin_token for admin API access or both admin_name and admin_key so the provider can mint one",
+		)
+	}
+	return diags
+}
+
 func (p *stepcaProvider) Resources(ctx context.Context) []func() resource.Resource {
-        return []func() resource.Resource{
-                NewCertificateResource,
-                NewProvisionerResource,
-                NewAdminResource,
-                NewTemplateResource,
-        }
+	return []func() resource.Resource{
+		NewCertificateResource,
+		NewProvisionerResource,
+		NewAdminResource,
+		NewTemplateResource,
+	}
 }
 
 func (p *stepcaProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
-        return []func() datasource.DataSource{
-                NewVersionDataSource,
-                NewCACertificateDataSource,
-                NewProvisionersDataSource,
-        }
+	return []func() datasource.DataSource{
+		NewVersionDataSource,
+		NewCACertificateDataSource,
+		NewProvisionersDataSource,
+	}
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,0 +1,79 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestValidateAdminCredentials(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		model   stepcaProviderModel
+		wantErr bool
+		summary string
+	}{
+		{
+			name: "token only",
+			model: stepcaProviderModel{
+				AdminToken: types.StringValue("token"),
+			},
+		},
+		{
+			name: "admin key pair",
+			model: stepcaProviderModel{
+				AdminName: types.StringValue("admin@example.com"),
+				AdminKey:  types.StringValue("/path/to/key"),
+			},
+		},
+		{
+			name: "token and key pair",
+			model: stepcaProviderModel{
+				AdminToken: types.StringValue("token"),
+				AdminName:  types.StringValue("admin@example.com"),
+				AdminKey:   types.StringValue("/path/to/key"),
+			},
+		},
+		{
+			name:    "missing all",
+			model:   stepcaProviderModel{},
+			wantErr: true,
+			summary: "missing admin credentials",
+		},
+		{
+			name: "name without key",
+			model: stepcaProviderModel{
+				AdminName: types.StringValue("admin@example.com"),
+			},
+			wantErr: true,
+			summary: "incomplete admin key configuration",
+		},
+		{
+			name: "key without name",
+			model: stepcaProviderModel{
+				AdminKey: types.StringValue("/path/to/key"),
+			},
+			wantErr: true,
+			summary: "incomplete admin key configuration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diags := validateAdminCredentials(&tt.model)
+			if diags.HasError() != tt.wantErr {
+				t.Fatalf("unexpected error state: %v", diags)
+			}
+			if tt.wantErr {
+				if len(diags) == 0 {
+					t.Fatalf("expected diagnostic")
+				}
+				if got := diags[0].Summary(); got != tt.summary {
+					t.Fatalf("unexpected summary: %s", got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- make the provider schema accept either an admin token or name/key pair and emit diagnostics when misconfigured
- document the credential validation rules in the README and provider docs
- add unit tests that cover the accepted and rejected admin credential combinations

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b24a40620832e812da608f27fba33)