### PR TITLE
Add template data source

### DIFF
--- a/docs/data-sources/template.md
+++ b/docs/data-sources/template.md
@@ -1,0 +1,35 @@
+---
+page_title: "stepca_template Data Source"
+subcategory: "Templates"
+description: |-
+  Fetch an existing X.509 or SSH template from step-ca via the admin API.
+---
+
+# stepca_template (Data Source)
+
+Use this data source to load the rendered body and metadata for a template that
+was previously stored in step-ca. The returned values let you reuse template
+content in multiple Terraform modules without duplicating JSON payloads.
+
+## Example Usage
+
+```hcl
+data "stepca_template" "ssh_admin" {
+  name = "ssh-admin"
+}
+
+output "template_body" {
+  value = jsondecode(data.stepca_template.ssh_admin.body)
+}
+```
+
+You can find a complete example in [`docs/examples/template/data-source.tf`](../examples/template/data-source.tf).
+
+## Argument Reference
+
+* `name` - (Required) The template name to fetch.
+
+## Attributes Reference
+
+* `body` - The template body returned by the admin API.
+* `metadata` - Optional metadata map stored alongside the template.

--- a/docs/examples/template/data-source.tf
+++ b/docs/examples/template/data-source.tf
@@ -1,0 +1,11 @@
+data "stepca_template" "ssh_admin" {
+  name = "ssh-admin"
+}
+
+output "ssh_admin_principals" {
+  value = jsondecode(data.stepca_template.ssh_admin.body).principals
+}
+
+output "ssh_admin_metadata" {
+  value = data.stepca_template.ssh_admin.metadata
+}

--- a/internal/provider/data_source_template.go
+++ b/internal/provider/data_source_template.go
@@ -1,0 +1,75 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/z0link/terraform-provider-stepca/internal/client"
+)
+
+var _ datasource.DataSource = &templateDataSource{}
+
+func NewTemplateDataSource() datasource.DataSource {
+	return &templateDataSource{}
+}
+
+type templateDataSource struct {
+	client templateGetter
+}
+
+type templateDataSourceModel struct {
+	Name     types.String `tfsdk:"name"`
+	Body     types.String `tfsdk:"body"`
+	Metadata types.Map    `tfsdk:"metadata"`
+}
+
+func (d *templateDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "stepca_template"
+}
+
+func (d *templateDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name":     schema.StringAttribute{Required: true},
+			"body":     schema.StringAttribute{Computed: true},
+			"metadata": schema.MapAttribute{Computed: true, ElementType: types.StringType},
+		},
+	}
+}
+
+func (d *templateDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	if c, ok := req.ProviderData.(*client.Client); ok {
+		d.client = c
+	}
+}
+
+func (d *templateDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	if d.client == nil {
+		resp.Diagnostics.AddError("provider not configured", "missing client")
+		return
+	}
+
+	var data templateDataSourceModel
+	diags := req.Config.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	body, metadata, helperDiags := GetTemplate(ctx, d.client, data.Name.ValueString())
+	resp.Diagnostics.Append(helperDiags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Body = types.StringValue(body)
+	data.Metadata = metadata
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/data_source_template_test.go
+++ b/internal/provider/data_source_template_test.go
@@ -1,0 +1,70 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/z0link/terraform-provider-stepca/internal/client"
+)
+
+func TestTemplateDataSourceSchema(t *testing.T) {
+	t.Parallel()
+
+	ds := NewTemplateDataSource()
+	var resp datasource.SchemaResponse
+	ds.Schema(context.Background(), datasource.SchemaRequest{}, &resp)
+
+	expected := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name":     schema.StringAttribute{Required: true},
+			"body":     schema.StringAttribute{Computed: true},
+			"metadata": schema.MapAttribute{Computed: true, ElementType: types.StringType},
+		},
+	}
+
+	if diff := cmp.Diff(expected, resp.Schema); diff != "" {
+		t.Fatalf("unexpected schema: (-want +got)\n%s", diff)
+	}
+}
+
+func TestGetTemplateMetadata(t *testing.T) {
+	t.Parallel()
+
+	fake := templateGetterFunc(func(ctx context.Context, name string) (*client.Template, error) {
+		return &client.Template{
+			Name: name,
+			Body: "body",
+			Metadata: map[string]string{
+				"team": "platform",
+			},
+		}, nil
+	})
+
+	body, metadata, diags := GetTemplate(context.Background(), fake, "example")
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", diags)
+	}
+	if body != "body" {
+		t.Fatalf("unexpected body %q", body)
+	}
+
+	var got map[string]string
+	if err := metadata.ElementsAs(context.Background(), &got, false); err != nil {
+		t.Fatalf("failed to decode metadata: %v", err)
+	}
+	want := map[string]string{"team": "platform"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("unexpected metadata: (-want +got)\n%s", diff)
+	}
+}
+
+type templateGetterFunc func(context.Context, string) (*client.Template, error)
+
+func (f templateGetterFunc) GetTemplate(ctx context.Context, name string) (*client.Template, error) {
+	return f(ctx, name)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -87,5 +87,6 @@ func (p *stepcaProvider) DataSources(ctx context.Context) []func() datasource.Da
                 NewVersionDataSource,
                 NewCACertificateDataSource,
                 NewProvisionersDataSource,
+                NewTemplateDataSource,
         }
 }

--- a/internal/provider/resource_template.go
+++ b/internal/provider/resource_template.go
@@ -13,10 +13,15 @@ import (
 
 var _ resource.Resource = &templateResource{}
 
+// templateGetter captures the helper interface for retrieving templates by name.
+type templateGetter interface {
+	GetTemplate(context.Context, string) (*client.Template, error)
+}
+
 // templateClient captures the subset of the client API this resource needs.
 type templateClient interface {
+	templateGetter
 	CreateTemplate(context.Context, client.Template) error
-	GetTemplate(context.Context, string) (*client.Template, error)
 	UpdateTemplate(context.Context, client.Template) error
 	DeleteTemplate(context.Context, string) error
 }

--- a/internal/provider/template_helpers.go
+++ b/internal/provider/template_helpers.go
@@ -1,0 +1,36 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// GetTemplate fetches a template body and metadata map from the admin API.
+func GetTemplate(ctx context.Context, getter templateGetter, name string) (string, types.Map, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	tmpl, err := getter.GetTemplate(ctx, name)
+	if err != nil {
+		diags = append(diags, diag.NewErrorDiagnostic("get template failed", err.Error()))
+		return "", types.MapNull(types.StringType), diags
+	}
+	if tmpl == nil {
+		diags = append(diags, diag.NewErrorDiagnostic("template not found", fmt.Sprintf("template %q was not found", name)))
+		return "", types.MapNull(types.StringType), diags
+	}
+
+	metadata := types.MapNull(types.StringType)
+	if len(tmpl.Metadata) > 0 {
+		val, mapDiags := types.MapValueFrom(ctx, types.StringType, tmpl.Metadata)
+		diags = append(diags, mapDiags...)
+		if diags.HasError() {
+			return tmpl.Body, metadata, diags
+		}
+		metadata = val
+	}
+
+	return tmpl.Body, metadata, diags
+}


### PR DESCRIPTION
## Summary
- add a `stepca_template` data source and shared helper to fetch template bodies and metadata
- document the data source and provide an example snippet for loading existing templates
- cover the schema and metadata decoding logic with unit tests

## Testing
- `go test ./...`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b24a29860832ea128ceefb9083456)